### PR TITLE
Fixed deleting orphans in Plone 5.1+ (CMFEditions 3).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.8 (unreleased)
 ----------------
 
+- Fixed deleting orphans in Plone 5.1+ (CMFEditions 3).
+  Fixes `issue #19 <https://github.com/collective/collective.revisionmanager/issues/19>`_.  [maurits]
+
 - Fixed startup error by loading the CMFCore zcml.  [maurits]
 
 - Do not fail on ``BrokenModified`` while calculating storage statistics.

--- a/src/collective/revisionmanager/browser/views.py
+++ b/src/collective/revisionmanager/browser/views.py
@@ -119,9 +119,10 @@ class HistoriesListView(BrowserPage):
                 if len(history['wcinfos']) > 1:
                     continue
                 wcinfo = history['wcinfos'][0]
-                if (wcinfo['url'] is None) and \
-                        wcinfo['path'].startswith('no working copy'):
-                    keys.append(history['history_id'])
+                if wcinfo['url'] is None:
+                    path = wcinfo['path']
+                    if path.startswith('no working copy') or path == 'All revisions have been purged':
+                        keys.append(history['history_id'])
             self._del_histories(keys)
         histories = stats.get('histories', [])
         sortkey = self._determine_sortkey()


### PR DESCRIPTION
Fixes issue #19.

I tested with this scenario:
- Create a Plone 5.0 site, install collective.revisionmanager.
- Create two pages, delete one of them.
- Upgrade to Plone 5.1
- Delete the second page.
- Recalculate the statistics.
- See screenshot with the 'List histories' tab:

![Screenshot 2019-10-03 at 12 08 25](https://user-images.githubusercontent.com/210587/66118453-ae354700-e5d6-11e9-99e7-e0efe35f2a0e.png)

- The item with history id 3 was deleted in Plone 5.0.
- The item with history id 4 was deleted in Plone 5.1.
- Click 'Delete orphans'.
- Result **without** my fix: only history id 3 is removed.
- Result **with** my fix: both history id 3 and 4 are removed.

The fix is to delete all items with one of the given texts in the path column. Note that these texts are [set by collective.revisionmanager itself](https://github.com/collective/collective.revisionmanager/blob/0.8/src/collective/revisionmanager/statscache.py#L123-L134) on-the-fly, so it is safe to rely on this.