### PR TITLE
Replace deprecated "self.context.translate" with "api.portal.translate"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes a bug in Plone 5.2 ('RequestContainer' object has no attribute
+  'translate')
+  [pysailor]
 
 
 1.0.0 (2020-08-18)

--- a/src/collective/revisionmanager/browser/views.py
+++ b/src/collective/revisionmanager/browser/views.py
@@ -82,10 +82,10 @@ class HistoriesListView(BrowserPage):
         sizestateid is either 'approximate' or 'inaccurate',
         defined in Products.CMFEditions.ZVCStorageTool.ShadowHistory.getSize
         """
-        return self.context.translate(self.size_states.get(sizestateid))
+        return api.portal.translate(self.size_states.get(sizestateid))
 
     def js_confirmation(self):
-        return self.context.translate(self.js_confirm)
+        return api.portal.translate(self.js_confirm)
 
     def reverse(self):
         return '1' if self.request.get('reverse', '0') == '0' else '0'


### PR DESCRIPTION
This prevents
AttributeError: 'RequestContainer' object has no attribute 'translate'
in Plone 5.2