### PR TITLE
Pin slighly newer buildout version to fix gh-actions.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -64,7 +64,7 @@ eggs =
 # Don't use a released version of the package under development
 collective.revisionmanager =
 
-# buildout stuff, probably good to have at least these ones the same in all Plone versions for Travis.
-setuptools = 41.2.0
-zc.buildout = 2.13.5
+# buildout stuff, probably good to have at least these ones the same in all Plone versions for GitHub Actions.
+setuptools = 42.0.2
+zc.buildout = 2.13.7
 zc.recipe.egg = 2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==41.2.0
-zc.buildout==2.13.5
+setuptools==42.0.2
+zc.buildout==2.13.7


### PR DESCRIPTION
One of the extended buildout configs uses `[versions:python37]`, leading to this error on older buildout versions:

    NameError: name 'python37' is not defined

See failed manual run:
https://github.com/collective/collective.revisionmanager/runs/7037758457?check_suite_focus=true#step:9:41